### PR TITLE
[WIP]トップページにおける出品商品一覧表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   
   def index
-    @items = Item.includes(:images)
+    @items = Item.includes(:images).where(status_id: "1").order(created_at: :desc)
   end
   
   def new

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -85,42 +85,21 @@
       .product__head
         =link_to "新規投稿商品", root_path
       .product__lists
-        .product__list
-          =link_to root_path do
-            =image_tag asset_path("material/pict/a004.png"), class: "product__list--img"
-            .product__list--body
-              %h3.name product3
-              .details
-                %ul
-                  %li 30000円
-                  %li
-                    =icon("fas", "star", class: "likeIcon")
-                    0
-                %p (税込)
-        .product__list
-          =link_to root_path do
-            =image_tag asset_path("material/pict/a005.png"), class: "product__list--img"
-            .product__list--body
-              %h3.name product2
-              .details
-                %ul
-                  %li 20000円
-                  %li
-                    =icon("fas", "star", class: "likeIcon")
-                    0
-                %p (税込)
-        .product__list
-          =link_to root_path do
-            =image_tag asset_path("material/pict/a006.png"), class: "product__list--img"
-            .product__list--body
-              %h3.name product1
-              .details
-                %ul
-                  %li 10000円
-                  %li
-                    =icon("fas", "star", class: "likeIcon")
-                    0
-                %p (税込)
+        - @items[0..2].each do |item|
+          .product__list
+            =link_to item_path(item.id) do
+              -item.images.each do |image|
+                =image_tag image.url, class: "product__list--img"
+              .product__list--body
+                %h3= item.name
+                .details
+                  %ul
+                    %li= "¥" + item.price.to_s
+                    %li
+                      =icon("fas", "star", class: "likeIcon")
+                      0
+                  %p (税込)
+        
 
   .pickup__container
     %h2.head ピックアップブランド
@@ -128,39 +107,18 @@
       .product__head
         =link_to "アーカイバ", root_path
       .product__lists
-        .product__list
-          =link_to root_path do
-            =image_tag asset_path("material/pict/a004.png"), class: "product__list--img"
-            .product__list--body
-              %h3.name product3
-              .details
-                %ul
-                  %li 30000円
-                  %li
-                    =icon("fas", "star", class: "likeIcon")
-                    0
-                %p (税込)
-        .product__list
-          =link_to root_path do
-            =image_tag asset_path("material/pict/a005.png"), class: "product__list--img"
-            .product__list--body
-              %h3.name product2
-              .details
-                %ul
-                  %li 20000円
-                  %li
-                    =icon("fas", "star", class: "likeIcon")
-                    0
-                %p (税込)
-        .product__list
-          =link_to root_path do
-            =image_tag asset_path("material/pict/a006.png"), class: "product__list--img"
-            .product__list--body
-              %h3.name product1
-              .details
-                %ul
-                  %li 10000円
-                  %li
-                    =icon("fas", "star", class: "likeIcon")
-                    0
-                %p (税込)
+        - @items[3..5].each do |item|
+          .product__list
+            =link_to item_path(item.id) do
+              -item.images.each do |image|
+                =image_tag image.url, class: "product__list--img"
+              .product__list--body
+                %h3= item.name
+                .details
+                  %ul
+                    %li= "¥" + item.price.to_s
+                    %li
+                      =icon("fas", "star", class: "likeIcon")
+                      0
+                  %p (税込)
+        

--- a/db/migrate/20200511022351_create_items.rb
+++ b/db/migrate/20200511022351_create_items.rb
@@ -11,6 +11,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.integer    :price        , null: false
       t.integer    :shipping_days, null: false
       t.string     :postage      , null: false
+      t.string     :status_id    , null: false
       t.references :user         , null: false, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2020_05_19_104751) do
     t.integer "price", null: false
     t.integer "shipping_days", null: false
     t.string "postage", null: false
+    t.string "status_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
What
トップページに出品した商品が新しく投稿された順に表示されるようにした。また、商品の販売状況で売り切れている商品は表示されないようになってる。{status_idが0の場合}

Why 
トップページで投稿商品が閲覧できることにより、ユーザビリティがアップし、商品購入までのプロセスにスムーズに行うことができる。

参考
https://i.gyazo.com/a162d020f6d062530569ac97a0f8de17.mp4
https://i.gyazo.com/d7c6d6f73383ad6ea48205e545e81de8.png
status_idが0の場合表示されない（この場合name6）