### PR TITLE
一覧表示のif文の追加

### DIFF
--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -100,7 +100,7 @@
                       0
                   %p (税込)
         
-
+-if @items.length > 3
   .pickup__container
     %h2.head ピックアップブランド
     .product_box


### PR DESCRIPTION
what 
商品が４つ以上ない場合、２段目の表示はなくなるように条件文を追記

Why
商品が少ない場合エラーが起きるため

https://i.gyazo.com/a61d520e8226c6bc2fa88b160f2daf62.png
https://i.gyazo.com/d30d9524581384b3164c0bf5aeccac2f.png
