### PR TITLE
修正:画像表示

### DIFF
--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -88,8 +88,8 @@
         - @items[0..2].each do |item|
           .product__list
             =link_to item_path(item.id) do
-              -item.images.each do |image|
-                =image_tag image, class: "product__list--img"
+              -item.images.first(1).each do |image|
+                =image_tag image.image.to_s, class: "product__list--img"
               .product__list--body
                 %h3= item.name
                 .details

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,11 +9,11 @@
         .itembox__body
           %ul
             %li
-              = image_tag @item.images[0], size:"560x346", class:"firstimage"
+              = image_tag @item.images[0].image.to_s, size:"560x346", class:"firstimage"
               %ul
                 -@item.images.each do |image|
                   %li
-                    = image_tag image, size:"140x87", class:"imagelist"
+                    = image_tag image.image.to_s, size:"140x87", class:"imagelist"
 
         .itembox__price
           = "¥#{@item.price}"


### PR DESCRIPTION
画像を表示されるようにして、トップページのピックアップカテゴリーの画像は最初の１枚のみを表示するようにしました。