### PR TITLE
【追加実装】パンくず機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ gem "omniauth-rails_csrf_protection"
 gem 'payjp'
 gem 'jquery-rails'
 gem 'kaminari'
+gem 'gretel'
 
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -402,6 +404,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,8 @@
 @import "templates/subheader";
 @import "templates/subfooter";
 @import "templates/error_messages";
+@import "templates/breadcrumbs";
+@import "templates/breadcrumbsitem";
 
 @import "modules/_creditcards";
 

--- a/app/assets/stylesheets/templates/_breadcrumbs.scss
+++ b/app/assets/stylesheets/templates/_breadcrumbs.scss
@@ -1,0 +1,18 @@
+.breadcrumbs{
+  .breadcrumbs-list{
+    display: flex;
+    line-height: 40px;
+    width: 1020px;
+    margin: 0 auto;
+    a{
+      margin: 0px 10px 0px 10px;
+      color: black;
+      font-size: 15px;
+    }
+    span{
+      margin: 0px 10px 0px 10px;
+      font-weight: bold;
+    }
+  }
+
+}

--- a/app/assets/stylesheets/templates/_breadcrumbsitem.scss
+++ b/app/assets/stylesheets/templates/_breadcrumbsitem.scss
@@ -1,0 +1,18 @@
+.breadcrumbs{
+  .breadcrumbs-list-item{
+    display: flex;
+    line-height: 40px;
+    width: 720px;
+    margin: 0 auto;
+    a{
+      margin: 0px 10px 0px 10px;
+      color: black;
+      font-size: 15px;
+    }
+    span{
+      margin: 0px 10px 0px 10px;
+      font-weight: bold;
+    }
+  }
+
+}

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -5,6 +5,8 @@
       = render "devise/sessions/header"
 
     .new_session-wrapper__main
+      - breadcrumb :address
+      = render "layouts/breadcrumbs" 
       .new_session-wrapper__main__head
         発送元・送り先住所の変更
       .new_session-wrapper__main__title

--- a/app/views/addresses/update.html.haml
+++ b/app/views/addresses/update.html.haml
@@ -3,6 +3,8 @@
     = render "devise/sessions/header"
     
   .new_session-wrapper__main
+    - breadcrumb :addressUpdate
+    = render "layouts/breadcrumbs"
     .new_session-wrapper__main__head
       変更が完了しました
     =link_to root_path, class:"new_session-wrapper__main__btn" do 

--- a/app/views/creditcards/index.html.haml
+++ b/app/views/creditcards/index.html.haml
@@ -1,5 +1,7 @@
 = render 'items/header'
 .mypage__container
+  - breadcrumb :creditcards
+  = render "layouts/breadcrumbs"
   .mypage__inner
     = render 'mypage/parts/side_list'
     .mypage-main.col-9

--- a/app/views/creditcards/new.html.haml
+++ b/app/views/creditcards/new.html.haml
@@ -1,5 +1,7 @@
 = render 'items/header'
 .mypage__container
+  - breadcrumb :newCreditcards
+  = render "layouts/breadcrumbs"
   .mypage__inner
     = render 'mypage/parts/side_list'
     = render 'creditcards/parts/card_add'

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -3,6 +3,8 @@
     = render "devise/sessions/header"
     
   .new_session-wrapper__main
+    - breadcrumb :createUser
+    = render "layouts/breadcrumbs"
     .new_session-wrapper__main__head
       登録が完了しました
     =link_to root_path, class:"new_session-wrapper__main__btn" do 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,7 +5,9 @@
     .new_session-wrapper__logo
       = render "devise/sessions/header"
 
-    .new_session-wrapper__main     
+    .new_session-wrapper__main
+      - breadcrumb :newUser
+      = render "layouts/breadcrumbs"
       .new_session-wrapper__main__head
         会員情報
       .new_session-wrapper__main__title

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -5,6 +5,8 @@
       = render "devise/sessions/header"
 
     .new_session-wrapper__main
+      - breadcrumb :newAddress
+      = render "layouts/breadcrumbs"
       .new_session-wrapper__main__head
         発送元・送り先住所
       .new_session-wrapper__main__title

--- a/app/views/favorites/index.html.haml
+++ b/app/views/favorites/index.html.haml
@@ -1,5 +1,7 @@
 = render 'items/header'
 .pickup__container
+  - breadcrumb :favorites
+  = render "layouts/breadcrumbs"
   %h2.head #{@nickname}さんのマイページ
   .product_box
     .product__head

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -1,6 +1,8 @@
 = render "/items/templates/subheader"
 
 .new-wrapper
+  - breadcrumb :itemCreate
+  = render "layouts/breadcrumbsitem"
   .new-wrapper__main
     .new-wrapper__main__create
       商品の出品が完了しました

--- a/app/views/items/done.html.haml
+++ b/app/views/items/done.html.haml
@@ -1,5 +1,7 @@
 = render "/items/templates/subheader"
 .done
+  -# - breadcrumb :done
+  -# = render "layouts/breadcrumbsitem"
   .done__content
     .done__content--box
       %h1.done__content--box--info 購入が完了しました

--- a/app/views/items/done.html.haml
+++ b/app/views/items/done.html.haml
@@ -1,7 +1,7 @@
 = render "/items/templates/subheader"
 .done
-  -# - breadcrumb :done
-  -# = render "layouts/breadcrumbsitem"
+  - breadcrumb :done
+  = render "layouts/breadcrumbsitem"
   .done__content
     .done__content--box
       %h1.done__content--box--info 購入が完了しました

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,5 +1,7 @@
 = render "/items/templates/subheader"
 .new-wrapper
+  - breadcrumb :itemEdit
+  = render "layouts/breadcrumbsitem"
   = form_with model: @item, local: true do |f|
     .new-wrapper__main
       .new-wrapper__main__title

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,5 +1,7 @@
 = render "/items/templates/subheader"
 .new-wrapper
+  - breadcrumb :itemNew
+  = render "layouts/breadcrumbsitem"
   = form_with model: @item, url: items_path, local: true do |f|
     .new-wrapper__main
       .new-wrapper__main__title

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -1,8 +1,8 @@
 = render "/items/templates/subheader"
 
 .purchase
-  -# - breadcrumb :purchase
-  -# = render "layouts/breadcrumbsitem"
+  - breadcrumb :purchase
+  = render "layouts/breadcrumbsitem"
   .purchase__main
     .purchase__main__title
       .purchase__main__title__text

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -1,6 +1,8 @@
 = render "/items/templates/subheader"
 
 .purchase
+  -# - breadcrumb :purchase
+  -# = render "layouts/breadcrumbsitem"
   .purchase__main
     .purchase__main__title
       .purchase__main__title__text

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,7 @@
 = render "/items/header"
-
 .main
+  - breadcrumb :itemShow
+  = render "layouts/breadcrumbsitem"
   .show-main
     .topcontents
       .itembox

--- a/app/views/items/update.html.haml
+++ b/app/views/items/update.html.haml
@@ -1,6 +1,8 @@
 = render "/items/templates/subheader"
 
 .new-wrapper
+  - breadcrumb :itemUpdate
+  = render "layouts/breadcrumbsitem"
   .new-wrapper__main
     .new-wrapper__main__create
       商品の編集が完了しました

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "", separator: "&rsaquo;", class: "breadcrumbs-list"

--- a/app/views/layouts/_breadcrumbsitem.html.haml
+++ b/app/views/layouts/_breadcrumbsitem.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "", separator: "&rsaquo;", class: "breadcrumbs-list-item"

--- a/app/views/mypage/_mypage.html.haml
+++ b/app/views/mypage/_mypage.html.haml
@@ -2,6 +2,3 @@
   .mypage__inner
     = render 'mypage/parts/side_list'
     = render 'mypage/parts/list_content'
-
-
-

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -1,5 +1,7 @@
 = render 'items/header'
 .mypage__container
+  - breadcrumb :mypage
+  = render "layouts/breadcrumbs"
   .mypage__inner
     = render 'mypage/parts/side_list'
     = render 'mypage/parts/index'

--- a/app/views/mypage/logout.html.haml
+++ b/app/views/mypage/logout.html.haml
@@ -1,5 +1,7 @@
 = render 'items/header'
 .mypage__container
+  - breadcrumb :logout
+  = render "layouts/breadcrumbs"
   .mypage__inner
     = render 'mypage/parts/side_list'
     = render 'mypage/parts/logout'

--- a/app/views/users/edit_detail.html.haml
+++ b/app/views/users/edit_detail.html.haml
@@ -3,7 +3,9 @@
   .new_session-wrapper
     .new_session-wrapper__logo   
       = render "devise/sessions/header"  
-    .new_session-wrapper__main     
+    .new_session-wrapper__main 
+      - breadcrumb :detail
+      = render "layouts/breadcrumbs"
       .new_session-wrapper__main__head
         メールアドレス・パスワード変更
       .new_session-wrapper__main__title

--- a/app/views/users/update_detail.html.haml
+++ b/app/views/users/update_detail.html.haml
@@ -3,6 +3,8 @@
     = render "devise/sessions/header"
     
   .new_session-wrapper__main
+    - breadcrumb :detailUpdate
+    = render "layouts/breadcrumbs"
     .new_session-wrapper__main__head
       変更が完了しました
     =link_to root_path, class:"new_session-wrapper__main__btn" do 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -62,8 +62,8 @@ crumb :logout do
 end
 
 crumb :itemShow do
-  link "商品詳細情報", "#"
-  link Item.find(params[:id]).name, "#"
+  link "商品詳細情報", item_path(Item.ids)
+  link Item.find(params[:id]).name, item_path(Item.ids)
   parent :root 
 end
 
@@ -87,13 +87,12 @@ crumb :itemCreate do
   parent :itemNew
 end
 
-# crumb :purchase do
-#   link "購入内容の確認", purchase_item_path(@item.id)
-#   link Item.find(params[:id]).name, "#"
-#   parent :itemShow
-# end
+crumb :purchase do
+  link "購入内容の確認", purchase_item_path(Item.ids)
+  parent :itemShow
+end
 
-# crumb :done do
-#   link "購入完了"
-#   parent :purchase
-# end
+crumb :done do
+  link "購入完了"
+  parent :purchase
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,99 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :newUser do
+  link "本人情報入力", new_user_registration_path
+  parent :root
+end
+
+crumb :newAddress do
+  link "本人住所入力", new_user_registration_path
+  parent :newUser
+end
+
+crumb :createUser do
+  link "登録完了"
+  parent :newAddress
+end
+
+crumb :mypage do 
+  link "マイページ", mypage_index_path
+end
+
+crumb :creditcards do
+  link "クレジットカード登録・削除", creditcard_path(current_user)
+  parent :mypage
+end
+
+crumb :newCreditcards do
+  link "クレジットカード情報入力"
+  parent :creditcards
+end
+
+crumb :favorites do
+  link "お気に入り商品", item_favorites_path(current_user)
+  parent :mypage
+end
+
+crumb :address do
+  link "発送元・お届け先住所変更", edit_address_path(current_user)
+  parent :mypage
+end
+
+crumb :addressUpdate do
+  link "変更完了"
+  parent :address
+end
+
+crumb :detail do
+  link "メールアドレス・パスワード変更", user_edit_detail_path(current_user)
+  parent :mypage
+end
+
+crumb :detailUpdate do
+  link "変更完了"
+  parent :detail
+end
+
+crumb :logout do
+  link "ログアウト"
+  parent :mypage
+end
+
+crumb :itemShow do
+  link "商品詳細情報", "#"
+  link Item.find(params[:id]).name, "#"
+  parent :root 
+end
+
+crumb :itemEdit do
+  link "商品情報編集", edit_item_path
+  parent :itemShow
+end
+
+crumb :itemUpdate do
+  link "変更完了"
+  parent :itemEdit
+end
+
+crumb :itemNew do
+  link "商品出品", new_item_path
+  parent :root
+end
+
+crumb :itemCreate do
+  link "出品完了"
+  parent :itemNew
+end
+
+# crumb :purchase do
+#   link "購入内容の確認", purchase_item_path(@item.id)
+#   link Item.find(params[:id]).name, "#"
+#   parent :itemShow
+# end
+
+# crumb :done do
+#   link "購入完了"
+#   parent :purchase
+# end


### PR DESCRIPTION
# What
上位の階層となるWEBページを階層順にリストアップしてリンクを設置したリストです。
下記の動作にパンくず機能を実装しました。
- 新規会員登録
- 会員情報編集（発送元、お届け先、メールアドレス、パスワード）
- 商品出品、詳細、編集、購入
- お気に入り機能
- クレジットカード登録、削除
# Why
ユーザーが今WEBサイト内のどの位置にいるのかを視覚的に分かりやすくするため実装しました。
# Gyazo
https://gyazo.com/55e3935891bc8fae2d98e572a7a59e65